### PR TITLE
Add errors classes and utilities

### DIFF
--- a/src/error.py
+++ b/src/error.py
@@ -1,0 +1,81 @@
+import json
+import werkzeug.exceptions
+import functools
+import traceback
+import requests
+import logging
+from flask import request
+from flask import Response as FlaskResponse
+
+
+logger = logging.getLogger(__name__)
+
+
+class CentillionException(Exception):
+    def __init__(self, status: int, code: str, title: str, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore
+        self.status = status
+        self.code = code
+        self.message = title
+
+
+class CentillionForbiddenException(DSSException):
+    def __init__(self, title: str = "User is not authorized to access this resource",
+                 *args, **kwargs) -> None:
+        super().__init__(requests.codes.forbidden,
+                         "Forbidden",
+                         title,
+                         *args, **kwargs)
+
+
+def centillion_exception_handler(e: CentillionException) -> FlaskResponse:
+    """
+    Turn Centillion exceptions into Flask exceptions.
+    This is added to the Flask app as an error handler.
+    
+    Example:
+
+        >>> from flask import Flask
+        >>> app = Flask(__name__)
+        >>> app.register_error_handler(CentillionException, centillion_exception_handler)
+    """
+    return FlaskResponse(
+        status=e.status,
+        mimetype="application/problem+json",
+        content_type="application/problem+json",
+        response=json.dumps({
+            'status': e.status,
+            'code': e.code,
+            'title': e.message,
+            'stacktrace': traceback.format_exc(),
+        }))
+
+
+
+def centillion_handler(func):
+    """
+    Generally, each route handler should be decorated with @centillion_handler, which manages exceptions.
+    Handlers that are not decorated are returned to app.common_error_handler(Exception).
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        method, path = request.method, request.path
+        try:
+            return func(*args, **kwargs)
+        except werkzeug.exceptions.HTTPException as ex:
+            status = ex.code
+            code = ex.name
+            title = str(ex)
+            stacktrace = traceback.format_exc()
+        except CentillionException as ex:
+            status = ex.status
+            code = ex.code
+            title = ex.message
+            stacktrace = traceback.format_exc()
+        except Exception as ex:
+            status = requests.codes.server_error
+            code = "unhandled_exception"
+            title = str(ex)
+            stacktrace = traceback.format_exc()
+        headers = None
+        logger.error(json.dumps(dict(status=status, code=code, title=title, stacktrace=stacktrace), indent=4))


### PR DESCRIPTION
This PR adds an `errors.py` defining a package-wide `CentillionException` and defining some utilities to aid in translating `CentillionException` into flask exceptions (incl. endpoint decorators to handle errors).

Base PR: #6