### PR TITLE
Add Github doctypes classes

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -58,6 +58,8 @@ class Config(object):
 
     _FOO: typing.Optional[str] = None
     _BAR: typing.Optional[str] = None
+    _CENTILLION_ROOT: typing.Optional[str] = None
+    _CENTILLION_TMPDIR: typing.Optional[str] = None
     _DOCTYPES_LIST: typing.Optional[typing.List[str]] = None
 
     @classmethod
@@ -75,6 +77,25 @@ class Config(object):
         return cls._BAR
 
     @classmethod
+    def get_centillion_root(cls) -> str:
+        if cls._CENTILLION_ROOT is None:
+            if 'centillion_root' in self._CONFIG:
+                cls._CENTILLION_ROOT = self._CONFIG['centillion_root']
+            else:
+                cls._CENTILLION_ROOT = get_required_env_var('CENTILLION_ROOT')
+            assert os.path.isdir(cls._CENTILLION_ROOT)
+        return cls._CENTILLION_ROOT
+
+    @classmethod
+    def get_centillion_tmpdir(cls) -> str:
+        if cls._CENTILLION_TMPDIR is None:
+            centillion_root = Config.get_centillion_root()
+            temp_dir = os.path.join(centillion_root, 'tmp')
+            if not os.path.exists(temp_dir):
+                subprocess.call(['mkdir', '-p', temp_dir])
+        return cls._CENTILLION_TMPDIR
+
+    @classmethod
     def get_doctypes(cls) -> typing.List[str]:
         """Return a list of all doctypes being indexed by centillion."""
         if cls._DOCTYPES_LIST is None:
@@ -84,3 +105,21 @@ class Config(object):
                 doctypes.add(cred['doctype'])
             cls._DOCTYPES_LIST = list(doctypes).sort()
         return cls._DOCTYPES_LIST
+
+    @classmethod
+    def get_doctypes_config(cls, name) -> typing.Dict[str, typing.Any]:
+        """
+        Return the section of the config file corresponding to this doctype.
+        This function allows us to keep the Config class from getting too
+        bogged down in the details of each class's configuration needs.
+
+        Example: instead of hard-coding how the Google Drive credentials
+        are stored in the config file and having a method here to get
+        those credentials, we leave it up to the Google Drive doctype
+        constructors to use this method and take care of the details.
+        """
+        doctypes_config = cls._CONFIG['doctypes']
+        if name not in doctypes_config:
+            raise Exception("Error: requested doctype section {name} not found in config file")
+        else:
+            return doctypes_config[name]

--- a/src/config.py
+++ b/src/config.py
@@ -58,6 +58,7 @@ class Config(object):
 
     _FOO: typing.Optional[str] = None
     _BAR: typing.Optional[str] = None
+    _DOCTYPES_LIST: typing.Optional[typing.List[str]] = None
 
     @classmethod
     def get_foo_var(cls) -> str:
@@ -72,3 +73,14 @@ class Config(object):
         if cls._BAR is None:
             cls._BAR = get_required_env_var('BAR')
         return cls._BAR
+
+    @classmethod
+    def get_doctypes(cls) -> typing.List[str]:
+        """Return a list of all doctypes being indexed by centillion."""
+        if cls._DOCTYPES_LIST is None:
+            doctypes = set()
+            doctypes_config = self._CONFIG['doctypes']
+            for cred in doctypes_config:
+                doctypes.add(cred['doctype'])
+            cls._DOCTYPES_LIST = list(doctypes).sort()
+        return cls._DOCTYPES_LIST

--- a/src/doctypes/__init__.py
+++ b/src/doctypes/__init__.py
@@ -3,3 +3,7 @@ from .registry import DoctypeRegistry
 
 # doctype contains base class
 from .doctype import Doctype
+
+def get_stemming_analyzer():
+    stemming_analyzer = StemmingAnalyzer() | LowercaseFilter()
+    return stemming_analyzer

--- a/src/doctypes/doctype.py
+++ b/src/doctypes/doctype.py
@@ -1,3 +1,4 @@
+"""Defines common doctype functionality"""
 import logging
 from whoosh import fields, index
 

--- a/src/doctypes/gdrive.py
+++ b/src/doctypes/gdrive.py
@@ -1,0 +1,280 @@
+"""Defines several Google Drive doctypes"""
+import os
+import subprocess
+import logging
+import datetime
+import pypandoc
+from dateutil.parser import parse
+from apiclient.discovery import build
+from httplib2 import Http
+from oauth2client import file, client, tools
+
+
+logger = logging.getLogger(__name__)
+
+
+###################
+# Utility functions
+###################
+
+def get_gdrive_service(token_path):
+    """
+    This requires that the operator do the following:
+
+    - Download client_secrets.json from API section of Google CLoud Console
+    - Run scripts/prepare_gdrive.py to convert client_secrets.json to credentials.json
+      (requires a one-time interactive login step)
+    - Put the credentials.json file in the path specified in the centillion config file
+
+    Then token_path above should be set to the path of credentials.json
+    """
+    SCOPES = 'https://www.googleapis.com/auth/drive.metadata.readonly'
+    store = file.Storage(token_path)
+    creds = store.get()
+    if not creds or creds.invalid:
+        raise Exception("Error: invalid or missing Google Drive API credentials")
+    service = build('drive', 'v3', http=creds.authorize(Http()))
+    return service.files()
+
+
+#################
+# Doctype classes
+#################
+
+class GDriveBaseDoctype(Doctype):
+    doctype = "gdrive_base"
+    """
+    Defines a base Google Drive document type.
+
+    All GDriveBaseDoctype subclasses will use
+    the same API instance, so use a common constructor
+    and validation method.
+
+    This base class only defines:
+    - constructor
+    - validate credentials
+    """
+    drive = None
+
+    def __init__(self, *args, **kwargs):
+        """
+        Constructor is only passed the name of the credentials.
+        Constructor uses name to get GDrive credentials.
+        """
+        self.name = args[0]
+        config = Config.get_doctypes_config(self.name)
+        self.token_path = config['token_path']
+        self.validate_credentials(self.token_path)
+
+    def validate_credentials(self, token_path):
+        if not os.path.exists(token_path):
+            raise Exception("Error: Google Drive token path does not exist: {token_path}")
+        if self.drive == None:
+            self.drive = get_gdrive_service(token_path)
+
+
+class GDriveFileDoctype(GDriveBaseDoctype):
+    doctype = "gdrive_file"
+    """
+    Defines a Google Drive file filetype.
+    This indexes the name/metadata of all files in a given
+    Google Drive folder/location.
+    """
+    schema = dict(
+        file_name = fields.TEXT(stored=True, field_boost=100.0),
+        file_url = fields.ID(stored=True),
+        mimetype = fields.TEXT(stored=True),
+        owner_email = fields.TEXT(stored=True),
+        owner_name = fields.TEXT(stored=True)
+    )
+
+    def get_remote_list(self) -> typing.List[typing.Tuple[datetime.datetime, str]]:
+        """
+        Compile a list of document IDs for documents that can be indexed
+        at the remote, and their last modified date.
+
+        Google Drive uses GDrive ID for the search index ID.
+
+        :returns: list of (last_modified_date, gdrive id) tuples
+                  (types are datetime.datetime and str)
+        """
+        name = self.name
+        drive = self.drive
+
+        # Return value: list of (last_modified_date, gdrive_id) tuples
+        remote_list = []
+
+        # To iterate over all files, use the list() function of drive
+        nextPageToken = None  # This is the trick to get this to work
+
+        # Use the pager to return all the things
+        while True:
+            ps = 100
+            results = drive.list(
+                    pageSize=ps,
+                    pageToken=nextPageToken,
+                    fields = "nextPageToken, files(id, kind, createdTime, modifiedTime, mimeType, name, owners, webViewLink)",
+                    spaces="drive"
+            ).execute()
+
+            nextPageToken = results.get("nextPageToken")
+            files = results.get("files",[])
+            for f in files:
+                fid = f['id']
+                fname = f['name']
+                ignore_file = self._ignore_file_check(fname)
+                if not ignore_file:
+                    key = fid
+                    date = dateutil.parser.parse(item['modifiedTime'])
+                    remote_list.append((date, key))
+
+        return remote_list
+
+    def get_by_id(self, doc_id):
+        """
+        Retrieve a remote document given its id, and return
+        an item to the search index matching the index schema.
+        """
+        # uses get method: https://developers.google.com/drive/api/v3/reference/files/get
+        item = driveService.files().get(doc_id)
+
+        doc = dict(
+            id = doc_id,
+            fingerprint = item['md5Checksum'],
+            kind = self.doctype,
+            created_time = dateutil.parser.parse(item['createdTime']),
+            modified_time = dateutil.parser.parse(item['modifiedTime']),
+            indexed_time = datetime.datetime.now(),
+            name = item['name'],
+            file_name = item['name'],
+            file_url = item['webViewLink'],
+            mimetype = item['mimeType'],
+            owner_email = item['owners'][0]['emailAddress'],
+            owner_name = item['owners'][0]['displayName']
+        )
+
+        return doc
+
+    def _ignore_file_check(self, fname):
+        """
+        Return True if this file should be ignored when assembling the remote list of files.
+        Subclasses can override this method to filter files by name.
+        They should check the result of super()._ignore_file_check(...) first.
+
+        :param fname: name of the file
+        :returns bool: return True if this file should be ignored when compiling the list of remote
+        """
+        # Eventually this will check if a GDriveDocxDoctype is activated
+        # If so, ignore docx files to avoid duplicate search index entries
+        return False
+
+class GDriveDocxDoctype(GDriveFileDoctype):
+    doctype = "gdrive_docx"
+    """
+    Defines a Google Drive docx filetype.
+    This indexes the name and contents of docx files, using
+    pandoc to convert the docx file to text that is indexed.
+    """
+    schema = dict(
+        **GDriveFileDoctype.schema,
+        content = fields.TEXT(stored=True)
+    )
+
+    def _ignore_file_check(self, fname):
+        fprefix, fext = os.path.splitext(fname)
+        if fext not in ['.docx', '.doc']:
+            return True
+        return False
+
+    def get_by_id(self, doc_id):
+        """
+        Retrieve a remote docx document given its id.
+        Use markdown to extract the text contents of the doc.
+        Assemble and return an item to the search index 
+        matching the search index schema.
+        """
+        # uses get method: https://developers.google.com/drive/api/v3/reference/files/get
+        item = driveService.files().get(doc_id)
+        content = self._extract_docx_content(item)
+        doc = super().get_by_id(doc_id)
+        doc['content'] = content
+
+    def _extract_docx_content(self, item):
+        content = ""
+        mimetype = re.split('[/\.]',item['mimeType'])[-1]
+        mimemap = {
+                'document' : 'docx',
+        }
+        if mimetype not in mimemap.keys():
+            # Not a document - just a file
+            return content
+
+        msg = f"Indexing content of Google Drive document \"{item['name'}\" of type \"{mimetype}\""
+        logger.info(msg)
+
+        msg = " > Extracting content"
+        logger.info(msg)
+
+        # Create a URL and a destination filename
+        file_ext = mimemap[mimetype]
+        file_url = "https://docs.google.com/document/d/%s/export?format=%s"%(item['id'], file_ext)
+
+        # This re could probablybe improved
+        name = re.sub('/','_',item['name'])
+
+        # Now make the pandoc input/output filenames
+        out_ext = 'txt'
+        pandoc_fmt = 'plain'
+        if name.endswith(file_ext):
+            infile_name = name
+            outfile_name = re.sub(file_ext, out_ext, infile_name)
+        else:
+            infile_name  = name+'.'+file_ext
+            outfile_name = name+'.'+out_ext
+
+        # Get the temporary directory, $CENTILLION_ROOT/tmp,
+        # from the config file (so everyone uses the same one)
+        temp_dir = Config.get_centillion_tmpdir()
+
+        # Assemble input/output file paths
+        fullpath_input = os.path.join(temp_dir,infile_name)
+        fullpath_output = os.path.join(temp_dir,outfile_name)
+
+        # Use requests.get to download url to file
+        r = requests.get(file_url, allow_redirects=True)
+        with open(fullpath_input, 'wb') as f:
+            f.write(r.content)
+
+        # Try to convert docx file to plain text
+        try:
+            output = pypandoc.convert_file(fullpath_input,
+                                           pandoc_fmt,
+                                           format='docx',
+                                           outputfile=fullpath_output
+            )
+            assert output == ""
+        except RuntimeError:
+            err = " > XXXXXX Failed to index Google Drive document \"%s\""%(item['name'])
+            logger.error(err)
+
+        # If export was successful, read contents of markdown
+        # into the content variable.
+        if os.path.isfile(fullpath_output):
+            # Export was successful
+            with codecs.open(fullpath_output, encoding='utf-8') as f:
+                content = f.read()
+
+        # No matter what happens, clean up.
+        msg = f" > Cleaning up \"{item['name']}\""
+        logger.info(msg)
+
+        clean_in_cmd = ['rm','-fr',fullpath_input]
+        clean_out_cmd = ['rm','-fr',fullpath_output]
+
+        logger.info(" > " + " ".join(clean_in_cmd))
+        subprocess.call(clean_in_cmd)
+
+        logger.info(" > " + " ".joout(clean_out_cmd))
+        subprocess.call(clean_out_cmd)
+
+        return content

--- a/src/doctypes/github.py
+++ b/src/doctypes/github.py
@@ -1,3 +1,4 @@
+"""Defines several Github doctypes"""
 import logging
 import typing
 import datetime

--- a/src/doctypes/github.py
+++ b/src/doctypes/github.py
@@ -1,0 +1,299 @@
+import logging
+import typing
+import datetime
+from urllib.parse import urlparse
+from centillion.doctypes.auth import GithubAuth
+from . import get_stemming_analyzer
+
+
+logger = logging.getLogger(__name__)
+
+
+###################
+# Utility functions
+###################
+
+def get_github_repos_list(name: str, g: typing.Any) -> typing.List[str]:
+    """
+    Use the config file to assemble a list of Github repositories to index.
+    Each Github doctype specifies repos/orgs in the config file.
+    Requires a valid Github API client g.
+
+    :param str name: name of doctype entry in config file
+    :param Github g: Github API client
+    :returns: list of repository names of form {org}/{repo}
+    """
+    repos_list = []
+
+    # Get list of repos for config orgs
+    orgs = Config.get_github_orgs(name)
+    for _, org in enumerate(orgs):
+        logger.debug(f'Adding repositories for organization {org}...')
+        # try/except here, if this fails try get_user()
+        org = g.get_organization(this_org)
+        repos = org.get_repos()
+        for repo in repos:
+            # Check this
+            logger.debug(f' + Adding repository {repo.full_name}')
+            repos_list.append(repo.full_name)
+
+    # Get list of repos from config repos
+    repos = Config.get_github_repos(self.name)
+    logger.debug(f'Adding repositories...')
+    for _, r in enumerate(repos):
+        if '/' not in r:
+            raise Exception("Error: invalid repo name specified")
+        this_org, this_repo = re.split('/',r)
+        try:
+            org = get_organization(this_org)
+            repo = org.get_repo(this_repo)
+        except:
+            try:
+                user = g.get_user(this_org)
+                repo = org.get_repo(this_repo)
+            except:
+                err = f"Error: could not gain access to repo {this_org}/{this_repo}"
+                raise Exception(err)
+
+        # Check this
+        logger.debug(f' + Adding repository {repo.full_name}')
+        repos_list.append(repo.full_name)
+
+    return repos_list
+
+
+#################
+# Doctype classes
+#################
+
+class GithubBaseDoctype(Doctype):
+    doctype = "github_base"
+    """
+    Defines a base Github document type.
+
+    All GithubBaseDoctype subclasses will use
+    the same kind of API instance, so we have a
+    common validation method, etc.
+
+    This base class only defines:
+    - constructor
+    - validate credentials
+    """
+    name: typing.Optional[str] = None
+    g: typing.Optional[Github] = None
+
+    def __init__(self, *args, **kwargs):
+        """
+        Constructor is only passed the name of the credentials.
+
+        Constructor uses name to get Github credentials, and all other
+        options set in the Config file for this set of credentials.
+        """
+        self.name = args[0]
+        self.access_token = Config.get_github_access_token(self.name)
+        self.validate_credentials(access_token)
+
+    def validate_credentials(self, access_token):
+        if self.g == None:
+            self.g = Github(access_token)
+
+
+def GithubIssuePRDoctype(GithubBaseDoctype):
+    doctype = "github_issue_pr"
+    """
+    Defines a Github pull request/issue doctype.
+    This indexes the contents of the threads of each
+    issue and pull request in Github repos.
+
+    Subclasses of GithubBaseDoctype must define the following:
+    - schema (class attribute)
+    - get_remote_list: list of remote document IDs and last modified date
+    - get_by_id: get document by index ID
+    - search result template (static)
+    """
+    schema = dict(
+        issue_title = fields.TEXT(stored=True, field_boost=100.0),
+        issue_url = fields.ID(stored=True),
+        repo_name = fields.TEXT(stored=True),
+        repo_url = fields.ID(stored=True),
+        github_user = fields.TEXT(stored=True),
+        content = fields.TEXT(stored=True, analyzer=get_stemming_analyzer())
+    )
+
+    def get_remote_list(self) -> typing.List[typing.Any]:
+        """
+        Compile a list of document IDs for documents that can be indexed
+        at the remote, and their last modified date.
+
+        Github types use the Github URL for the search index ID.
+
+        :returns: list of tuples of the form:
+                  (last-modified-date, id)
+                  where last-modified-date is a datetime object
+                  and id is a string (search index id).
+        """
+        name = self.name
+        g = self.g
+
+        # This stores our (last-modified-date, id) tuples
+        remote_list = []
+
+        # Iterate over each repo and store all keys + modified date
+        repos_list = get_repos_list(name, g)
+        for repo_name in repos_list:
+            repo = g.get_repo(repo_name)
+
+            # Iterate over issues and PRs, adding to list
+            for get in [repo.get_issues, repo.get_pulls]:
+                for state in ['open', 'closed']:
+                    items = repo.get(state=state)
+                    for _, item in enumerate(items):
+                        # Add an item (issue/PR) to the list
+                        key = item.html_url
+                        date = item.updated_at
+                        remote_list.append((date, key))
+
+        return remote_list
+
+    def get_by_id(self, doc_id):
+        """
+        Retrieve a remote document given its search index id
+        (Github URL for all Github doctypes), and return an
+        item to the search index matching the index schema.
+        """
+        g = self.g
+
+        # The doc_id is the Github URL, turn it into a PyGithub object
+        p = urlparse(doc_id)
+        path_pieces = p.path.split('/')
+
+        # Get repo reference
+        repo_name = "/".join(path_pieces[1:3])
+        repo_url = f"https://github.com/{repo_name}"
+        repo = g.get_repo(repo_name)
+
+        # Get issue/PR reference (get_issue and get_pull are interchangeable!)
+        number = int(path_pieces[-1])
+        item = g.get_pull(number)
+
+        msg = f"Indexing issue {repo_name}#{number}"
+        logging.info(msg)
+
+        content = extract_issue_pr_contents(item)
+
+        doc = dict(
+            id = doc_id,
+            kind = self.doctype,
+            created_time = item.created_at,
+            modified_time = item.updated_at,
+            indexed_time = datetime.datetime.now(),
+            name = item.title,
+            issue_title = item.title,
+            issue_url = item.html_url,
+            repo_name = repo_name,
+            repo_url = repo_url,
+            github_user = item.user.login,
+            content = content
+        )
+
+        return doc
+
+
+    def extract_issue_pr_content(self, issue) -> str:
+        """
+        Given a PyGithub Issue/PullRequest object, extract the content
+        of the issue/PR, including original body + all comments.
+
+        :param issue: PyGithub Issue/PullRequest
+        :returns: a string containing the contents of the issue/PR
+        """
+        content = ""
+
+        if issue is None or issue.body is None:
+            return content
+
+        # Body first
+        try:
+            content = issue.body.rstrip()
+            content += "\n"
+        except AttributeError:
+            pass
+
+        # Comments second
+        if(issue.comments > 0):
+            try:
+                comments = issue.get_comments()
+                for comment in comments:
+                    try:
+                        content += comment.body.rstrip()
+                    except AttributeError:
+                        pass
+                    content += "\n"
+            except GithubException:
+                err = f"Error: could not get comments for issue {repo_name}#{number}"
+                logger.error(err)
+                pass
+
+        return content
+
+
+
+class GithubFileDoctype(GithubBaseDoctype):
+    doctype = "github_file"
+    """
+    Defines a Github file doctype.
+    This indexes the names/metadata of all files in Github repos.
+    (...every branch?? of every repo??)
+    """
+    schema = {}
+
+    def get_remote_list(self):
+        """
+        Compile a list of document IDs for documents that can be indexed
+        at the remote, and their last modified date.
+
+        Github types use the Github URL for the search index ID.
+
+        :returns: list of tuples of the form:
+                  (last-modified-date, id)
+                  where last-modified-date is a datetime object
+                  and id is a string (search index id).
+        """
+        repos_list = get_repos_list(self.name, self.g)
+
+    def get_by_id(self, doc_id):
+        """
+        Retrieve a remote document given its id, and return
+        an item to the search index matching the index schema.
+        """
+        pass
+
+
+class GithubMarkdownDoctype(GithubBaseDoctype):
+    doctype = "github_markdown"
+    """
+    Defines a Github markdown file doctype.
+    This indexes the content of all Markdown files in Github repos.
+    """
+    schema = {}
+
+    def get_remote_list(self) -> typing.List[typing.Any]:
+        """
+        Compile a list of document IDs for documents that can be indexed
+        at the remote, and their last modified date.
+
+        Github types use the Github URL for the search index ID.
+
+        :returns: list of tuples of the form:
+                  (last-modified-date, id)
+                  where last-modified-date is a datetime object
+                  and id is a string (search index id).
+        """
+        repos_list = get_github_repos_list(self.name, self.g)
+
+    def get_by_id(self, doc_id):
+        """
+        Retrieve a remote document given its id, and return
+        an item to the search index matching the index schema.
+        """
+        pass

--- a/src/doctypes/github.py
+++ b/src/doctypes/github.py
@@ -175,7 +175,7 @@ class GithubBaseDoctype(Doctype):
         """
         self.name = args[0]
         self.access_token = Config.get_github_access_token(self.name)
-        self.validate_credentials(access_token)
+        self.validate_credentials(self.access_token)
 
     def validate_credentials(self, access_token):
         if self.g == None:

--- a/src/doctypes/github.py
+++ b/src/doctypes/github.py
@@ -1,9 +1,11 @@
 """Defines several Github doctypes"""
 import logging
 import typing
+import re
+import base64
 import datetime
 from urllib.parse import urlparse
-from centillion.doctypes.auth import GithubAuth
+from github import Github, GithubException
 from . import get_stemming_analyzer
 
 
@@ -14,24 +16,105 @@ logger = logging.getLogger(__name__)
 # Utility functions
 ###################
 
-def get_github_repos_list(name: str, g: typing.Any) -> typing.List[str]:
+def get_gh_file_url(repo_name: str, branch_name: str, repo_path: str) -> str:
+    """
+    Assemble a Github HTML URL to a file on a branch of a Github repo.
+
+    :param repo_name: full repo name in the form {1}/{2}
+    :param branch_name: name of the branch this file is on
+    :param repo_path: full path and filename of the file, from the root of the repo
+    :returns: Github HTML URL that leads to the file on the branch of the repo
+    """
+    return f'https://github.com/{repo_name}/blob/{branch_name}/{repo_path}'
+
+def convert_gh_file_html_url_to_raw_url(gh_file_html_url: str) -> str:
+    """
+    Return the Github raw URL for a given a Github HTML URL to a file on a branch of a Github repo.
+
+    :param gh_file_html_url: Github HTML URL to the file on the branch of the repo
+    :returns: Github raw URL that leads to the file on the branch of the repo
+    """
+    u = re.sub('github.com', 'raw.githubusercontent.com', gh_file_html_url, 1)
+    u = re.sub('blob/', '', u, 1)
+    return u
+
+def get_repo_branch_from_file_url(gh_url: str) -> typing.Tuple[str, str]:
+    """
+    Extract the full repo name, branch name, and repo path from a Github file HTML URL.
+
+    :param gh_url: Github HTML URL of the form https://github.com/{1}/{2}/blob/{3}/...
+    :returns: tuple with three strings (full repo name, branch name, repo path)
+    """
+    p = urlparse(gh_url)
+    path_pieces = p.path.split('/')
+    repo_name = "/".join(path_pieces[1:3])
+    branch_name = path_pieces[4]
+    reepopath = "/".join(path_pieces[5:])
+    return (repo_name, branch_name, repo_path)
+
+def get_repo_name_from_url(gh_url: str) -> str:
+    """
+    Extract the full repo name from a Github HTML URL.
+
+    :param gh_url: Github HTML URL of the form https://github.com/{1}/{2}/...
+    :returns: full repo name
+    """
+    p = urlparse(gh_url)
+    path_pieces = p.path.split('/')
+    repo_name = "/".join(path_pieces[1:3])
+    return repo_name
+
+def get_issue_pr_no_from_url(gh_url: str) -> int:
+    """
+    Extract the issue/PR number from a Github HTML URL.
+
+    :param gh_url: Github HTML URL of the form https://github.com/{1}/{2}/.../#
+    :returns: int corresponding to PR/issue number
+    """
+    p = urlparse(gh_url)
+    path_pieces = p.path.split('/')
+    number = int(path_pieces[-1])
+    return number
+
+def get_pygithub_branch_refs(repo_name: str, branch_name: str, g):
+    """
+    Given a repo and branch name, return PyGithub objects referring to
+    the repo, the branch, and the head commit of the branch, in a tuple.
+
+    :param repo_name: full name of repository of form {1}/{2}
+    :param branch_name: name of branch
+    :param g: Github API client
+    :returns: tuple of form (repo_obj, branch_obj, head_commit_obj)
+    """
+    repo = g.get_repo(repo_name)
+    branch = repo.get_branch(branch_name)
+    head_commit = branch.commit
+    return (repo, branch, head_commit)
+
+def get_github_repos_list(name: str, g) -> typing.List[str]:
     """
     Use the config file to assemble a list of Github repositories to index.
     Each Github doctype specifies repos/orgs in the config file.
     Requires a valid Github API client g.
 
     :param str name: name of doctype entry in config file
-    :param Github g: Github API client
+    :param g: Github API client
     :returns: list of repository names of form {org}/{repo}
     """
     repos_list = []
 
     # Get list of repos for config orgs
     orgs = Config.get_github_orgs(name)
-    for _, org in enumerate(orgs):
-        logger.debug(f'Adding repositories for organization {org}...')
-        # try/except here, if this fails try get_user()
-        org = g.get_organization(this_org)
+    for _, this_org in enumerate(orgs):
+        logger.debug(f'Adding repositories for Github org {this_org}...')
+        try:
+            org = g.get_organization(this_org)
+        except:
+            try:
+                org = g.get_user(this_org)
+            except:
+                err = f"Error: could not gain access to Github org/user {this_org}"
+                raise Exception(err)
         repos = org.get_repos()
         for repo in repos:
             # Check this
@@ -46,7 +129,7 @@ def get_github_repos_list(name: str, g: typing.Any) -> typing.List[str]:
             raise Exception("Error: invalid repo name specified")
         this_org, this_repo = re.split('/',r)
         try:
-            org = get_organization(this_org)
+            org = g.get_organization(this_org)
             repo = org.get_repo(this_repo)
         except:
             try:
@@ -116,27 +199,24 @@ def GithubIssuePRDoctype(GithubBaseDoctype):
         issue_title = fields.TEXT(stored=True, field_boost=100.0),
         issue_url = fields.ID(stored=True),
         repo_name = fields.TEXT(stored=True),
-        repo_url = fields.ID(stored=True),
-        github_user = fields.TEXT(stored=True),
+        github_user = fields.KEYWORD(stored=True, lowercase=True, commas=True),
         content = fields.TEXT(stored=True, analyzer=get_stemming_analyzer())
     )
 
-    def get_remote_list(self) -> typing.List[typing.Any]:
+    def get_remote_list(self) -> typing.List[typing.Tuple[datetime.datetime, str]]:
         """
         Compile a list of document IDs for documents that can be indexed
         at the remote, and their last modified date.
 
         Github types use the Github URL for the search index ID.
 
-        :returns: list of tuples of the form:
-                  (last-modified-date, id)
-                  where last-modified-date is a datetime object
-                  and id is a string (search index id).
+        :returns: list of (last_modified_date, issue_pr_url) tuples
+                  (types are datetime.datetime and str)
         """
         name = self.name
         g = self.g
 
-        # This stores our (last-modified-date, id) tuples
+        # Return value: list of (last_modified_date, issue_pr_url) tuples
         remote_list = []
 
         # Iterate over each repo and store all keys + modified date
@@ -147,7 +227,7 @@ def GithubIssuePRDoctype(GithubBaseDoctype):
             # Iterate over issues and PRs, adding to list
             for get in [repo.get_issues, repo.get_pulls]:
                 for state in ['open', 'closed']:
-                    items = repo.get(state=state)
+                    items = get(state=state)
                     for _, item in enumerate(items):
                         # Add an item (issue/PR) to the list
                         key = item.html_url
@@ -162,25 +242,21 @@ def GithubIssuePRDoctype(GithubBaseDoctype):
         (Github URL for all Github doctypes), and return an
         item to the search index matching the index schema.
         """
+        msg = f"Indexing issue {repo_name}#{number}"
+        logger.info(msg)
+
         g = self.g
 
-        # The doc_id is the Github URL, turn it into a PyGithub object
-        p = urlparse(doc_id)
-        path_pieces = p.path.split('/')
-
         # Get repo reference
-        repo_name = "/".join(path_pieces[1:3])
-        repo_url = f"https://github.com/{repo_name}"
+        repo_name = get_repo_name_from_url(doc_id)
         repo = g.get_repo(repo_name)
 
         # Get issue/PR reference (get_issue and get_pull are interchangeable!)
-        number = int(path_pieces[-1])
+        number = get_issue_pr_no_from_url(doc_id)
         item = g.get_pull(number)
 
-        msg = f"Indexing issue {repo_name}#{number}"
-        logging.info(msg)
-
-        content = extract_issue_pr_contents(item)
+        user_list = self._extract_issue_pr_user_list(item)
+        content = self._extract_issue_pr_content(item)
 
         doc = dict(
             id = doc_id,
@@ -192,15 +268,36 @@ def GithubIssuePRDoctype(GithubBaseDoctype):
             issue_title = item.title,
             issue_url = item.html_url,
             repo_name = repo_name,
-            repo_url = repo_url,
-            github_user = item.user.login,
+            github_user = user_list,
             content = content
         )
 
         return doc
 
+    def _extract_issue_pr_user_list(self, item) -> str:
+        """
+        Given a PyGithub Issue/PullRequest object, extract a list of
+        Github users related to the item (creator, commentors, assignees, etc.)
 
-    def extract_issue_pr_content(self, issue) -> str:
+        :param item: Github Issue/PullRequest to extract user list from
+        :returns: comma-separated list of Github user handles related to this issue/PR
+        """
+        user_list = []
+
+        user_list.append(item.user.login)
+        for assignee in item.assignees:
+            user_list.append(assignee.login)
+        if(item.comments > 0):
+            try:
+                comments = item.get_comments()
+                for comment in comments:
+                    user_list.append(comment.user.login)
+            except GithubException:
+                pass
+
+        return ",".join(user_list)
+
+    def _extract_issue_pr_content(self, item) -> str:
         """
         Given a PyGithub Issue/PullRequest object, extract the content
         of the issue/PR, including original body + all comments.
@@ -210,33 +307,32 @@ def GithubIssuePRDoctype(GithubBaseDoctype):
         """
         content = ""
 
-        if issue is None or issue.body is None:
+        if item is None or item.body is None:
             return content
 
         # Body first
         try:
-            content = issue.body.rstrip()
+            content = item.body.rstrip()
             content += "\n"
         except AttributeError:
             pass
 
         # Comments second
-        if(issue.comments > 0):
+        if(item.comments > 0):
             try:
-                comments = issue.get_comments()
+                comments = item.get_comments()
                 for comment in comments:
                     try:
                         content += comment.body.rstrip()
+                        content += "\n"
                     except AttributeError:
                         pass
-                    content += "\n"
             except GithubException:
-                err = f"Error: could not get comments for issue {repo_name}#{number}"
+                err = f"Error: could not get comments for issue/PR {repo_name}#{number}"
                 logger.error(err)
                 pass
 
         return content
-
 
 
 class GithubFileDoctype(GithubBaseDoctype):
@@ -246,55 +342,246 @@ class GithubFileDoctype(GithubBaseDoctype):
     This indexes the names/metadata of all files in Github repos.
     (...every branch?? of every repo??)
     """
-    schema = {}
+    schema = dict(
+        file_name = fields.TEXT(stored=True, field_boost=100.0),
+        file_url = fields.ID(stored=True),
+        repo_path = fields.TEXT(stored=True),
+        repo_name = fields.TEXT(stored=True),
+        github_user = fields.KEYWORD(stored=True, lowercase=True, commas=True)
+    )
 
-    def get_remote_list(self):
+    def get_remote_list(self) -> typing.List[typing.Tuple[datetime.datetime, str]]:
         """
         Compile a list of document IDs for documents that can be indexed
         at the remote, and their last modified date.
 
         Github types use the Github URL for the search index ID.
 
-        :returns: list of tuples of the form:
-                  (last-modified-date, id)
-                  where last-modified-date is a datetime object
-                  and id is a string (search index id).
+        :returns: list of (last_modified_date, issue_pr_url) tuples
+                  (types are datetime.datetime and str)
         """
+        name = self.name
+        g = self.g
+
+        # Return value: list of (last_modified_date, file_url) tuples
+        remote_list = []
+
         repos_list = get_repos_list(self.name, self.g)
+        for repo_name in repos_list:
+            repo = g.get_repo(repo_name)
+
+            # What about other branches?
+            # What about other commits?
+
+            # To iterate over all files, we need a git tree, which requires a commit reference.
+            # Get head commit of default branch
+            try:
+                default_branch = repo.get_branch(repo.default_branch)
+                head_commit = default_branch.commit
+                sha = head_commit.sha
+            except GithubException:
+                err = f"Error: could not fetch commits from default branch of repository {repo_name}"
+                logger.error(err)
+                continue
+
+            # Get all the docs
+            tree = repo.get_git_tree(sha=sha, recursive=True)
+            docs = tree.raw_data['tree']
+            msg = "Parsing file ids from repository %s"%(r)
+            logger.info(msg)
+            for item in docs:
+                # Split document path into its useful parts
+                fpath = d['path']
+                _, fname = os.path.split(fpath)
+                _, fext = os.path.splitext(fpath)
+                fpathpieces = fpath.split('/')
+                # NOTE:
+                # This method should be redefined to filter on specific file types
+                # when defining a new Github file doctype
+                ignore_file = self._ignore_file_check(fname, fext, fpathpieces)
+                if not ignore_file:
+                    # PyGithub doesn't provide an HTML URL for files,
+                    # but we can assemble one ourselves.
+                    key = get_gh_file_url(repo_name, branch_name, item['path'])
+                    date = head_commit.commit.author.date
+                    remote_list.append((date, key))
+
+        return remote_list
+
+    def ignore_file_check(self, fname: str, fext: str, fpathpieces: typing.List[str]) -> bool:
+        """
+        Return True if this file should be ignored when assembling the remote list of files.
+        Subclasses can override this method to return remote lists but with filtered filetypes.
+        They should check the result of super().ignore_file_check(...) first, if True then pass it along,
+        otherwise do our own checks.
+
+        :param fname: name of the file
+        :param fext: extension of the file
+        :param pathpieces: pieces of the relative repository path of the file
+        :returns bool: return True if this file should be ignored when compiling the list of remote
+        """
+        # Ignore anything whose name starts with . or _
+        if fname[0]=='.' or fname[0]=='_':
+            return True
+
+        for piece in fpathpieces:
+            if piece[0]=='.' or piece[0]=='_':
+                return True
+
+        return False
 
     def get_by_id(self, doc_id):
         """
         Retrieve a remote document given its id, and return
         an item to the search index matching the index schema.
         """
-        pass
+        # Extract labels from URL
+        repo_name, branch_name, repo_path = get_repo_branch_from_file_url(doc_id)
+
+        # Get PyGithub objects from labels
+        repo, branch, head_commit = get_pygithub_branch_refs(repo_name, branch_name, self.g)
+
+        # Convenience
+        g = self.g
+        file_name = repo_path.split('/')[-1]
+
+        msg = f"Indexing file {repo_path} in repo {repo_name}"
+        logger.info(msg)
+
+        doc = dict(
+            id = doc_id,
+            kind = self.doctype,
+            created_time = None,
+            modified_time = head_commit.commit.author.date,
+            indexed_time = datetime.datetime.now(),
+            name = file_name,
+            file_name = file_name,
+            file_url = doc_id,
+            repo_path = repo_path,
+            github_user = head_commit.author.login
+        )
+
+        return doc
 
 
-class GithubMarkdownDoctype(GithubBaseDoctype):
+class GithubMarkdownDoctype(GithubFileDoctype):
     doctype = "github_markdown"
     """
     Defines a Github markdown file doctype.
     This indexes the content of all Markdown files in Github repos.
     """
-    schema = {}
+    schema = dict(
+        file_name = fields.TEXT(stored=True, field_boost=100.0),
+        file_url = fields.ID(stored=True),
+        repo_path = fields.TEXT(stored=True),
+        repo_name = fields.TEXT(stored=True),
+        github_user = fields.KEYWORD(stored=True, lowercase=True, commas=True),
+        content = fields.TEXT(stored=True, analyzer=get_stemming_analyzer())
+    )
 
-    def get_remote_list(self) -> typing.List[typing.Any]:
+    def ignore_file_check(self, fname: str, fext: str, fpathpieces: typing.List[str]) -> bool:
         """
-        Compile a list of document IDs for documents that can be indexed
-        at the remote, and their last modified date.
+        Return True if this file should be ignored when assembling the remote list of files.
+        Extends GithubFileDoctype.ignore_file_check
 
-        Github types use the Github URL for the search index ID.
-
-        :returns: list of tuples of the form:
-                  (last-modified-date, id)
-                  where last-modified-date is a datetime object
-                  and id is a string (search index id).
+        :param fname: name of the file
+        :param fext: extension of the file
+        :param pathpieces: pieces of the relative repository path of the file
+        :returns bool: return True if this file should be ignored when compiling the list of remote
         """
-        repos_list = get_github_repos_list(self.name, self.g)
+        if super().ignore_file_check(fname, fext, fpathpieces):
+            return True
+
+        if fext not in [".md", ".markdown"]:
+            return True
+
+        return False
 
     def get_by_id(self, doc_id):
         """
         Retrieve a remote document given its id, and return
         an item to the search index matching the index schema.
         """
-        pass
+        # Extract labels from URL
+        repo_name, branch_name, repo_path = get_repo_branch_from_file_url(doc_id)
+
+        # Get PyGithub objects from labels
+        repo, _, head_commit = get_pygithub_branch_refs(repo_name, branch_name, self.g)
+
+        # Convenience
+        g = self.g
+        file_name = repo_path.split('/')[-1]
+
+        msg = f"Indexing Markdown file {repo_path} in repo {repo_name}"
+        logger.info(msg)
+
+        markdown_user_list = head_commit.author.login
+
+        content = self._extract_markdown_content(repo, head_commit, repo_path)
+
+        doc = dict(
+            id = doc_id,
+            fingerprint = sha,
+            kind = self.doctype,
+            created_time = None,
+            modified_time = head_commit.commit.author.date,
+            indexed_time = datetime.datetime.now(),
+            name = file_name,
+            file_name = file_name,
+            file_url = doc_id,
+            repo_path = repo_path,
+            github_user = head_commit.author.login
+        )
+
+        return doc
+
+    def _extract_markdown_content(self, repo, head_commit, repo_path):
+        """
+        Extract the content of a markdown file located at repo_path in repo at commit head_commit.
+
+        :param repo: PyGithub Repository object
+        :param head_commit: PyGithub Commit object corresponding to head commit of branch of interest
+        :param repo_path: relative path in the repo to the markdown file of interest
+        """
+        content = ""
+
+        # Get a reference to the tree to get a list of files + URLs to access their contents
+        sha = head_commit.sha
+        tree = repo.get_git_tree(sha=sha, recursive=True)
+        docs = tree.raw_data['tree']
+
+        # Find the doc we are interested in
+        doc = None
+        for d in docs:
+            if d['path']==repo_path:
+                doc = d
+        if doc is None:
+            err = f"Error: No file found matching {path} in repo {repo.full_name} commit {sha}."
+            logger.error(err)
+            return content
+
+        # The API URL will be a JSON document whose "content" field has the document contents.
+        # Make a request to the API URL and decode the result. Include headers for private repos!
+        # Useful: https://bit.ly/2LSAflS
+        headers = {'Authorization' : 'token %s'%(gh_token)}
+        url = doc['url']
+        response = requests.get(url, headers=headers)
+        if response.status_code==200:
+            jresponse = response.json()
+            try:
+                binary_content = re.sub('\n','',jresponse['content'])
+                content = base64.b64decode(binary_content).decode('utf-8')
+                return content
+            except KeyError:
+                err = f"Error: Failed to extract 'content' field from response to {url}.\n"
+                err += "You probably hit the Github API rate limit."
+                logger.error(err)
+                return content
+            else:
+                err = f"Error: Failed to decode JSON from {url}. There may be a problem with authentication/headers."
+                logger.error(err)
+                return content
+        else:
+            msg = f"Error: Github returned status code {response.status_code}"
+            logger.error(msg)
+            logger.error(str(response))

--- a/src/doctypes/github.py
+++ b/src/doctypes/github.py
@@ -182,7 +182,7 @@ class GithubBaseDoctype(Doctype):
             self.g = Github(access_token)
 
 
-def GithubIssuePRDoctype(GithubBaseDoctype):
+class GithubIssuePRDoctype(GithubBaseDoctype):
     doctype = "github_issue_pr"
     """
     Defines a Github pull request/issue doctype.
@@ -408,12 +408,11 @@ class GithubFileDoctype(GithubBaseDoctype):
 
         return remote_list
 
-    def ignore_file_check(self, fname: str, fext: str, fpathpieces: typing.List[str]) -> bool:
+    def _ignore_file_check(self, fname: str, fext: str, fpathpieces: typing.List[str]) -> bool:
         """
         Return True if this file should be ignored when assembling the remote list of files.
         Subclasses can override this method to return remote lists but with filtered filetypes.
-        They should check the result of super().ignore_file_check(...) first, if True then pass it along,
-        otherwise do our own checks.
+        They should check the result of super()._ignore_file_check(...) first.
 
         :param fname: name of the file
         :param fext: extension of the file
@@ -471,25 +470,21 @@ class GithubMarkdownDoctype(GithubFileDoctype):
     This indexes the content of all Markdown files in Github repos.
     """
     schema = dict(
-        file_name = fields.TEXT(stored=True, field_boost=100.0),
-        file_url = fields.ID(stored=True),
-        repo_path = fields.TEXT(stored=True),
-        repo_name = fields.TEXT(stored=True),
-        github_user = fields.KEYWORD(stored=True, lowercase=True, commas=True),
+        **GithubFileDoctype.schema,
         content = fields.TEXT(stored=True, analyzer=get_stemming_analyzer())
     )
 
-    def ignore_file_check(self, fname: str, fext: str, fpathpieces: typing.List[str]) -> bool:
+    def _ignore_file_check(self, fname: str, fext: str, fpathpieces: typing.List[str]) -> bool:
         """
         Return True if this file should be ignored when assembling the remote list of files.
-        Extends GithubFileDoctype.ignore_file_check
+        Extends GithubFileDoctype._ignore_file_check
 
         :param fname: name of the file
         :param fext: extension of the file
         :param pathpieces: pieces of the relative repository path of the file
         :returns bool: return True if this file should be ignored when compiling the list of remote
         """
-        if super().ignore_file_check(fname, fext, fpathpieces):
+        if super()._ignore_file_check(fname, fext, fpathpieces):
             return True
 
         if fext not in [".md", ".markdown"]:

--- a/src/doctypes/registry.py
+++ b/src/doctypes/registry.py
@@ -1,3 +1,4 @@
+"""Define a metaclass for the registry pattern"""
 import logging
 
 


### PR DESCRIPTION
Adds Github doctype classes:

* `GithubBaseDoctype` - defines common functionality (constructor, credential validation)
* `GithubIssuePRDoctype` - defines doctype for github issue/pull request
* `GithubFileDoctype` - defines doctype for github file in a repo
* `GithubMarkdownDoctype` - defines dotype for github markdown file in a repo

Closes #11
 
Closes #12

Closes #13